### PR TITLE
Update for newer exiv2

### DIFF
--- a/src/exiv2wrapper.hpp
+++ b/src/exiv2wrapper.hpp
@@ -264,7 +264,7 @@ private:
     std::string _filename;
     Exiv2::byte* _data;
     long _size;
-    Exiv2::Image::AutoPtr _image;
+    Exiv2::Image::UniquePtr _image;
     Exiv2::ExifData* _exifData;
     Exiv2::IptcData* _iptcData;
     Exiv2::XmpData* _xmpData;


### PR DESCRIPTION
Just some maintenance fixes to make this work with newer versions of exiv2. There were some enum changes and type issues with error handling, and pBuf in Exiv2::DataBuf was made private. 
Tested with gxx=14.1, exiv2=0.28.3 and libboost*=1.86.0.